### PR TITLE
修复生成.d.ts文件失败的bug 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ function compile(modules) {
 
   let hasError = false
 
-  const source = ['src/components/**/*.tsx', 'src/components/**/*.ts', 'src/components/**/*.d.ts']
+  const source = ['src/components/**/*.tsx', 'src/components/**/*.ts', 'src/components/**/*.d.ts', 'src/typings/**/*.d.ts']
 
   if (tsConfig.allowJs) {
     source.unshift('src/components/**/*.jsx')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,13 +98,16 @@ function compile(modules) {
       })
     )
     .pipe(
-      ts(tsConfig, {
-        error(err) {
-          ts.reporter.defaultReporter().error(err)
-          hasError = true
-        },
-        finish: ts.reporter.defaultReporter().finish,
-      })
+      ts(
+        { ...tsConfig, noEmit: false, isolatedModules: false },
+        {
+          error(err) {
+            ts.reporter.defaultReporter().error(err)
+            hasError = true
+          },
+          finish: ts.reporter.defaultReporter().finish,
+        }
+      )
     )
 
   function check() {

--- a/src/components/aside/Aside.tsx
+++ b/src/components/aside/Aside.tsx
@@ -2,7 +2,7 @@ import React, { useState, ReactNode, useContext } from 'react'
 import { Layout, Menu } from 'antd'
 import { useCancel } from '../_hooks'
 import { MailOutlined } from '@ant-design/icons'
-import logo from '../../assets/logo.png'
+// import logo from '../../assets/logo.png'
 import { Link } from 'react-router-dom'
 import useClasses from '../_hooks/useClasses'
 import { AsideContext } from './store'
@@ -108,7 +108,7 @@ export default function Aside(props: AsideProps) {
       // onBreakpoint={onBreakPoint}
     >
       <div className={`${prefixCls}-logo`}>
-        <img src={logo} alt={title} />
+        {/* <img src={logo} alt={title} /> */}
         {!collapsed && <span>{title}</span>}
       </div>
       <Menu theme="dark" mode="inline">

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,2 @@
 export { default as Button } from './button'
-export { default as Aside } from './aside'
+export { default as Layout } from './layout'

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import ProLayout, { MenuDataItem, BasicLayoutProps, PageHeaderWrapper } from '@ant-design/pro-layout'
 import useClasses from '../_hooks/useClasses'
-// import logo from '../../assets/logo.png'
+import logo from '../../assets/logo.png'
 import { useCancel } from '../_hooks'
 import { Link } from 'react-router-dom'
 import { MailOutlined } from '@ant-design/icons'
@@ -136,7 +136,7 @@ export default function Layout(props: LayoutProps) {
 
   return (
     <ProLayout
-      // logo={logo}
+      logo={logo}
       title={title}
       className={classes}
       collapsed={collapsed}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import ProLayout, { MenuDataItem, BasicLayoutProps, PageHeaderWrapper } from '@ant-design/pro-layout'
 import useClasses from '../_hooks/useClasses'
-import logo from '../../assets/logo.png'
+// import logo from '../../assets/logo.png'
 import { useCancel } from '../_hooks'
 import { Link } from 'react-router-dom'
 import { MailOutlined } from '@ant-design/icons'
@@ -136,7 +136,7 @@ export default function Layout(props: LayoutProps) {
 
   return (
     <ProLayout
-      logo={logo}
+      // logo={logo}
       title={title}
       className={classes}
       collapsed={collapsed}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,1 +1,3 @@
-export * from './Layout'
+import Layout from './Layout'
+
+export default Layout

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.png'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "noImplicitReturns": false,
     "experimentalDecorators": true,
     "declaration": true,
+    "isolatedModules": true,
     "noEmit": true
   },
   "exclude": ["node_modules", "lib", "es"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "assets": ["src/assets/*"]
-    },
     "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
@@ -22,7 +19,6 @@
     "noImplicitReturns": false,
     "experimentalDecorators": true,
     "declaration": true,
-    "isolatedModules": true,
     "noEmit": true
   },
   "exclude": ["node_modules", "lib", "es"],


### PR DESCRIPTION
tsconfig声明declaration为true后，仍然生成.d.ts失败。
error TS5053: Option 'declaration' cannot be specified with option 'isolatedModules'.

参考文章：
[为什么声明不能与typescript中的isolatedModules一起使用？](https://dev.to/yvonnickfrin/how-to-handle-peer-dependencies-when-developing-modules-18fa)